### PR TITLE
Deal with shodan ban

### DIFF
--- a/recon/shodan.py
+++ b/recon/shodan.py
@@ -22,6 +22,7 @@ class Shodan(Request):
 				method = 'GET',
 				url = url
 				)
+			if resp.status_code != 200: return b'{}'
 			return resp.content
 		except Exception as e:
 			pass


### PR DESCRIPTION
When shodan bans the request, the response does not meet the expected format (Forbidden response).