### PR TITLE
Fix crash when -h is used after another argument

### DIFF
--- a/infoga.py
+++ b/infoga.py
@@ -74,7 +74,7 @@ class infoga(object):
 			if o in ('-i','--info'):
 				self.listEmail.append(checkEmail(a))
 				plus('Searching for: %s'%a)
-			if o in ('-h','--help'):usage(True)
+			if o in ('-h','--help'):Banner().usage(True)
 		### start ####
 		if self.domain != ('' or None):
 			if self.source == 'ask':self.engine(self.domain,'ask')


### PR DESCRIPTION
Fix undefined function call to `usage(True)` when `-h` is used after another argument. 

```bash
python infoga.py --domain domain.com -h
________________________________________
-==[ Infoga - Email OSINT 
-==[ Momo (m4ll0k) Outaadi 
-==[ https://github.com/m4ll0k 
________________________________________

Traceback (most recent call last):
  File "infoga.py", line 109, in <module>
    infoga().main()
  File "infoga.py", line 77, in main
    if o in ('-h','--help'):usage(True)
NameError: global name 'usage' is not defined
```

This call should be `Banner().usage(True)`.

